### PR TITLE
OK! looks like ipykernel is needed to run within OnDemand jupyter not…

### DIFF
--- a/containers/dockerfile_gpuhoomd3conda
+++ b/containers/dockerfile_gpuhoomd3conda
@@ -6,4 +6,6 @@ RUN conda update -n base -c defaults conda && \
     conda info && \
     conda install mamba -n base -c conda-forge && \
     mamba install -c conda-forge hoomd=3*=*gpu* cudatoolkit=10.2 python && \
-    mamba install -c conda-forge mbuild gsd ipython ipykernel freud cassandra 
+    mamba install -c conda-forge mbuild gsd ipython ipykernel freud cassandra && \ 
+    mamba install -c conda-forge mdanalysis nglview vim && \
+    conda install -c bioconda gromacs 


### PR DESCRIPTION
…ebooks

But there's still an issue with  this image not working on non-gpu nodes